### PR TITLE
Fix: support .au timezones

### DIFF
--- a/CRM/Icaltimezone/ICal.php
+++ b/CRM/Icaltimezone/ICal.php
@@ -23,7 +23,7 @@ class CRM_Icaltimezone_ICal extends CRM_Core_Page {
    * Else outputs iCalendar format per IETF RFC2445. Page param true means send
    * to browser as inline content. Else, we send .ics file as attachment.
    */
-  public function run() {
+  public static function run() {
     $id = CRM_Utils_Request::retrieveValue('id', 'Positive', NULL, FALSE, 'GET');
     $type = CRM_Utils_Request::retrieveValue('type', 'Positive', 0);
     $start = CRM_Utils_Request::retrieveValue('start', 'Positive', 0);

--- a/CRM/Icaltimezone/ICal.php
+++ b/CRM/Icaltimezone/ICal.php
@@ -77,7 +77,7 @@ LEFT JOIN civicrm_address ca ON ca.id = clb.address_id
 LEFT JOIN civicrm_state_province csp ON csp.id = ca.state_province_id
 WHERE ce.id = %1";
     $params = [1 => [$id, 'Integer']];
-    $state = CRM_Core_DAO::executeQuery($sql, $params);
+    $state = CRM_Core_DAO::singleValueQuery($sql, $params);
 
     $eventTimezones = [
       'ACT' => 'Australia/Canberra',

--- a/CRM/Icaltimezone/ICal.php
+++ b/CRM/Icaltimezone/ICal.php
@@ -16,6 +16,13 @@
  */
 class CRM_Icaltimezone_ICal extends CRM_Core_Page {
 
+  // AG: PHP 8+ requires callback functions to be declared statically.
+  // So we create a static wrapper method:
+  public static function callback() {
+    $instance = new self();
+    return $instance->run();
+  }
+
   /**
    * Heart of the iCalendar data assignment process. The runner gets all the meta
    * data for the event and calls the  method to output the iCalendar
@@ -23,7 +30,7 @@ class CRM_Icaltimezone_ICal extends CRM_Core_Page {
    * Else outputs iCalendar format per IETF RFC2445. Page param true means send
    * to browser as inline content. Else, we send .ics file as attachment.
    */
-  public static function run() {
+  public function run() {
     $id = CRM_Utils_Request::retrieveValue('id', 'Positive', NULL, FALSE, 'GET');
     $type = CRM_Utils_Request::retrieveValue('type', 'Positive', 0);
     $start = CRM_Utils_Request::retrieveValue('start', 'Positive', 0);

--- a/CRM/Icaltimezone/ICal.php
+++ b/CRM/Icaltimezone/ICal.php
@@ -88,7 +88,7 @@ WHERE ce.id = %1";
       foreach (['start_date', 'end_date', 'registration_start_date', 'registration_end_date'] as $dateField) {
         if (!empty($eventInfo[$dateField])) {
           $dateObj = new DateTime($eventInfo[$dateField], $defaultTimezone);
-          $eventInfo[$dateField] = self::convertDateToLocalTime($dateObj, 'Y-m-d H:i:s', $userTimeZone);
+          $eventInfo[$dateField] = self::convertDateToLocalTime($dateObj, $userTimeZone, 'Y-m-d H:i:s');
         }
       }
     }
@@ -131,7 +131,7 @@ WHERE ce.id = %1";
    * @param string $format
    * @return string
    */
-  public static function convertDateToLocalTime($dateObject, $format = 'YmdHis', $userTimeZone) {
+  public static function convertDateToLocalTime($dateObject, $userTimeZone, $format = 'YmdHis') {
     $systemTimeZone = new DateTimeZone($userTimeZone);
     $dateObject->setTimezone($systemTimeZone);
     return $dateObject->format($format);

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+  "name": "australian_greens/nz.co.fuzion.icaltimezone",
+  "type": "civicrm-ext",
+  "description": "CiviCRM extension to improve iCal timezone support",
+  "require": {
+    "composer/installers": "^1.6 || ^2"
+  }
+}
+

--- a/icaltimezone.civix.php
+++ b/icaltimezone.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Icaltimezone_ExtensionUtil {
-  const SHORT_NAME = "icaltimezone";
-  const LONG_NAME = "nz.co.fuzion.icaltimezone";
-  const CLASS_PREFIX = "CRM_Icaltimezone";
+  const SHORT_NAME = 'icaltimezone';
+  const LONG_NAME = 'nz.co.fuzion.icaltimezone';
+  const CLASS_PREFIX = 'CRM_Icaltimezone';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,7 +24,7 @@ class CRM_Icaltimezone_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = []) {
+  public static function ts($text, $params = []): string {
     if (!array_key_exists('domain', $params)) {
       $params['domain'] = [self::LONG_NAME, NULL];
     }
@@ -41,7 +41,7 @@ class CRM_Icaltimezone_ExtensionUtil {
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
+  public static function url($file = NULL): string {
     if ($file === NULL) {
       return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }
@@ -79,45 +79,29 @@ class CRM_Icaltimezone_ExtensionUtil {
 
 use CRM_Icaltimezone_ExtensionUtil as E;
 
+function _icaltimezone_civix_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
+  }
+}
+
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _icaltimezone_civix_civicrm_config(&$config = NULL) {
+function _icaltimezone_civix_civicrm_config($config = NULL) {
   static $configured = FALSE;
   if ($configured) {
     return;
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
-
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
-
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function _icaltimezone_civix_civicrm_xmlMenu(&$files) {
-  foreach (_icaltimezone_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+  _icaltimezone_civix_mixin_polyfill();
 }
 
 /**
@@ -127,35 +111,7 @@ function _icaltimezone_civix_civicrm_xmlMenu(&$files) {
  */
 function _icaltimezone_civix_civicrm_install() {
   _icaltimezone_civix_civicrm_config();
-  if ($upgrader = _icaltimezone_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function _icaltimezone_civix_civicrm_postInstall() {
-  _icaltimezone_civix_civicrm_config();
-  if ($upgrader = _icaltimezone_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function _icaltimezone_civix_civicrm_uninstall() {
-  _icaltimezone_civix_civicrm_config();
-  if ($upgrader = _icaltimezone_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
+  _icaltimezone_civix_mixin_polyfill();
 }
 
 /**
@@ -163,210 +119,9 @@ function _icaltimezone_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _icaltimezone_civix_civicrm_enable() {
+function _icaltimezone_civix_civicrm_enable(): void {
   _icaltimezone_civix_civicrm_config();
-  if ($upgrader = _icaltimezone_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- * @return mixed
- */
-function _icaltimezone_civix_civicrm_disable() {
-  _icaltimezone_civix_civicrm_config();
-  if ($upgrader = _icaltimezone_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function _icaltimezone_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _icaltimezone_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
-}
-
-/**
- * @return CRM_Icaltimezone_Upgrader
- */
-function _icaltimezone_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/Icaltimezone/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_Icaltimezone_Upgrader_Base::instance();
-  }
-}
-
-/**
- * Search directory tree for files which match a glob pattern.
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
- *
- * @param string $dir base dir
- * @param string $pattern , glob pattern, eg "*.txt"
- *
- * @return array(string)
- */
-function _icaltimezone_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_icaltimezone_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
-}
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function _icaltimezone_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _icaltimezone_civix_find_files(__DIR__, '*.mgd.php');
-  sort($mgdFiles);
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function _icaltimezone_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_icaltimezone_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function _icaltimezone_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _icaltimezone_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_themes().
- *
- * Find any and return any files matching "*.theme.php"
- */
-function _icaltimezone_civix_civicrm_themes(&$themes) {
-  $files = _icaltimezone_civix_glob(__DIR__ . '/*.theme.php');
-  foreach ($files as $file) {
-    $themeMeta = include $file;
-    if (empty($themeMeta['name'])) {
-      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
-    }
-    if (empty($themeMeta['ext'])) {
-      $themeMeta['ext'] = E::LONG_NAME;
-    }
-    $themes[$themeMeta['name']] = $themeMeta;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- *
- * @return array, possibly empty
- */
-function _icaltimezone_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : [];
+  _icaltimezone_civix_mixin_polyfill();
 }
 
 /**
@@ -385,8 +140,8 @@ function _icaltimezone_civix_insert_navigation_menu(&$menu, $path, $item) {
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
       ], $item),
     ];
     return TRUE;
@@ -449,29 +204,4 @@ function _icaltimezone_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parent
       _icaltimezone_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
   }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _icaltimezone_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-
-function _icaltimezone_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-  ));
 }

--- a/icaltimezone.php
+++ b/icaltimezone.php
@@ -13,15 +13,6 @@ function icaltimezone_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_xmlMenu().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function icaltimezone_civicrm_xmlMenu(&$files) {
-  _icaltimezone_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
@@ -31,114 +22,12 @@ function icaltimezone_civicrm_install() {
 }
 
 /**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function icaltimezone_civicrm_postInstall() {
-  _icaltimezone_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function icaltimezone_civicrm_uninstall() {
-  _icaltimezone_civix_civicrm_uninstall();
-}
-
-/**
  * Implements hook_civicrm_enable().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function icaltimezone_civicrm_enable() {
   _icaltimezone_civix_civicrm_enable();
-}
-
-/**
- * Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- */
-function icaltimezone_civicrm_disable() {
-  _icaltimezone_civix_civicrm_disable();
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function icaltimezone_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _icaltimezone_civix_civicrm_upgrade($op, $queue);
-}
-
-/**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function icaltimezone_civicrm_managed(&$entities) {
-  _icaltimezone_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function icaltimezone_civicrm_caseTypes(&$caseTypes) {
-  _icaltimezone_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function icaltimezone_civicrm_angularModules(&$angularModules) {
-  _icaltimezone_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function icaltimezone_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _icaltimezone_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
- * Implements hook_civicrm_entityTypes().
- *
- * Declare entity types provided by this module.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function icaltimezone_civicrm_entityTypes(&$entityTypes) {
-  _icaltimezone_civix_civicrm_entityTypes($entityTypes);
-}
-
-/**
- * Implements hook_civicrm_thems().
- */
-function icaltimezone_civicrm_themes(&$themes) {
-  _icaltimezone_civix_civicrm_themes($themes);
 }
 
 /**
@@ -158,9 +47,8 @@ function icaltimezone_civicrm_alterMenu(&$items) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
  *
-function icaltimezone_civicrm_preProcess($formName, &$form) {
 
-} // */
+ // */
 
 /**
  * Implements hook_civicrm_navigationMenu().

--- a/icaltimezone.php
+++ b/icaltimezone.php
@@ -36,7 +36,7 @@ function icaltimezone_civicrm_enable() {
 function icaltimezone_civicrm_alterMenu(&$items) {
   $items['civicrm/event/ical']['page_callback'] = [
     'CRM_Icaltimezone_ICal',
-    'run',
+    'callback',
   ];
 }
 

--- a/info.xml
+++ b/info.xml
@@ -14,17 +14,23 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-04-28</releaseDate>
-  <version>1.0</version>
+  <releaseDate>2024-07-30</releaseDate>
+  <version>1.1</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.27</ver>
   </compatibility>
   <comments>This is a new, undeveloped module</comments>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
+    <psr0 prefix="CRM_" path="."/>
   </classloader>
   <civix>
     <namespace>CRM/Icaltimezone</namespace>
+    <format>23.02.1</format>
   </civix>
+  <mixins>
+    <mixin>menu-xml@1.0.0</mixin>
+    <mixin>smarty-v2@1.0.1</mixin>
+  </mixins>
 </extension>

--- a/mixin/menu-xml@1.0.0.mixin.php
+++ b/mixin/menu-xml@1.0.0.mixin.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Auto-register "xml/Menu/*.xml" files.
+ *
+ * @mixinName menu-xml
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::xmlMenu()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_xmlMenu', function ($e) use ($mixInfo) {
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $files = (array) glob($mixInfo->getPath('xml/Menu/*.xml'));
+    foreach ($files as $file) {
+      $e->files[] = $file;
+    }
+  });
+
+};

--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * When deploying on systems that lack mixin support, fake it.
+ *
+ * @mixinFile polyfill.php
+ *
+ * This polyfill does some (persnickity) deduplication, but it doesn't allow upgrades or shipping replacements in core.
+ *
+ * Note: The polyfill.php is designed to be copied into extensions for interoperability. Consequently, this file is
+ * not used 'live' by `civicrm-core`. However, the file does need a canonical home, and it's convenient to keep it
+ * adjacent to the actual mixin files.
+ *
+ * @param string $longName
+ * @param string $shortName
+ * @param string $basePath
+ */
+return function ($longName, $shortName, $basePath) {
+  // Construct imitations of the mixin services. These cannot work as well (e.g. with respect to
+  // number of file-reads, deduping, upgrading)... but they should be OK for a few months while
+  // the mixin services become available.
+
+  // List of active mixins; deduped by version
+  $mixinVers = [];
+  foreach ((array) glob($basePath . '/mixin/*.mixin.php') as $f) {
+    [$name, $ver] = explode('@', substr(basename($f), 0, -10));
+    if (!isset($mixinVers[$name]) || version_compare($ver, $mixinVers[$name], '>')) {
+      $mixinVers[$name] = $ver;
+    }
+  }
+  $mixins = [];
+  foreach ($mixinVers as $name => $ver) {
+    $mixins[] = "$name@$ver";
+  }
+
+  // Imitate CRM_Extension_MixInfo.
+  $mixInfo = new class() {
+
+    /**
+     * @var string
+     */
+    public $longName;
+
+    /**
+     * @var string
+     */
+    public $shortName;
+
+    public $_basePath;
+
+    public function getPath($file = NULL) {
+      return $this->_basePath . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
+
+    public function isActive() {
+      return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+    }
+
+  };
+  $mixInfo->longName = $longName;
+  $mixInfo->shortName = $shortName;
+  $mixInfo->_basePath = $basePath;
+
+  // Imitate CRM_Extension_BootCache.
+  $bootCache = new class() {
+
+    public function define($name, $callback) {
+      $envId = \CRM_Core_Config_Runtime::getId();
+      $oldExtCachePath = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+      $stat = stat($oldExtCachePath);
+      $file = Civi::paths()->getPath('[civicrm.compile]/CachedMixin.' . md5($name . ($stat['mtime'] ?? 0)) . '.php');
+      if (file_exists($file)) {
+        return include $file;
+      }
+      else {
+        $data = $callback();
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        return $data;
+      }
+    }
+
+  };
+
+  // Imitate CRM_Extension_MixinLoader::run()
+  // Parse all live mixins before trying to scan any classes.
+  global $_CIVIX_MIXIN_POLYFILL;
+  foreach ($mixins as $mixin) {
+    // If the exact same mixin is defined by multiple exts, just use the first one.
+    if (!isset($_CIVIX_MIXIN_POLYFILL[$mixin])) {
+      $_CIVIX_MIXIN_POLYFILL[$mixin] = include_once $basePath . '/mixin/' . $mixin . '.mixin.php';
+    }
+  }
+  foreach ($mixins as $mixin) {
+    // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
+    if (!isset(\Civi::$statics[$longName][$mixin])) {
+      \Civi::$statics[$longName][$mixin] = 1;
+      $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
+      $func($mixInfo, $bootCache);
+    }
+  }
+};

--- a/mixin/smarty-v2@1.0.1.mixin.php
+++ b/mixin/smarty-v2@1.0.1.mixin.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Auto-register "templates/" folder.
+ *
+ * @mixinName smarty-v2
+ * @mixinVersion 1.0.1
+ * @since 5.59
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+  $dir = $mixInfo->getPath('templates');
+  if (!file_exists($dir)) {
+    return;
+  }
+
+  $register = function() use ($dir) {
+    // This implementation has a theoretical edge-case bug on older versions of CiviCRM where a template could
+    // be registered more than once.
+    CRM_Core_Smarty::singleton()->addTemplateDir($dir);
+  };
+
+  // Let's figure out what environment we're in -- so that we know the best way to call $register().
+
+  if (!empty($GLOBALS['_CIVIX_MIXIN_POLYFILL'])) {
+    // Polyfill Loader (v<=5.45): We're already in the middle of firing `hook_config`.
+    if ($mixInfo->isActive()) {
+      $register();
+    }
+    return;
+  }
+
+  if (CRM_Extension_System::singleton()->getManager()->extensionIsBeingInstalledOrEnabled($mixInfo->longName)) {
+    // New Install, Standard Loader: The extension has just been enabled, and we're now setting it up.
+    // System has already booted. New templates may be needed for upcoming installation steps.
+    $register();
+    return;
+  }
+
+  // Typical Pageview, Standard Loader: Defer the actual registration for a moment -- to ensure that Smarty is online.
+  \Civi::dispatcher()->addListener('hook_civicrm_config', function() use ($mixInfo, $register) {
+    if ($mixInfo->isActive()) {
+      $register();
+    }
+  });
+
+};


### PR DESCRIPTION
**Description**

This extension improves the handling of timezones in iCal files in CiviCRM. Out of the box it takes the timezones of the server, and the browser requesting the iCal file, then generates an iCal file that adjusts the times according to the browser timezone.

This PR takes this base functionality and updates it to account for the Australian state/territory of the event. Specifically:
* it retrieves the state/territory abbreviation of the address associated with the event
* uses that abbreviation as a key to retrieve an appropriate timezone for the event
* uses this timezone as the basis for calculating appropriate timezone changes for the end user
* defaults to the server's timezone if the event has no state/territory abbreviation

The PR also makes these changes, all of which are in service of PHP 8.1 compatibility:
* updates civix to the latest version
* reorders required & optional parameters in an extension function
* adds a static function wrapper around the extension's run() function, which is non-static (by virtue of inheritance from CRM_Core_Page::run()

**Testing**

This has been tested in dev as follows:
* create an event in the WA domain
* give the event a WA address
* download the iCal file for the event _before_ enabling the extension
* download the iCal file for the event _after_ enabling the extension
* comparing the contents of each file

For a WA event running 10am-2pm...

Here's the relevant parts of the iCal file _before_ using the extension:
```
X-WR-TIMEZONE:Australia/Melbourne
...
DTSTAMP;TZID=Australia/Melbourne:20240803T100000
DTSTART;TZID=Australia/Melbourne:20240803T100000
DTEND;TZID=Australia/Melbourne:20240803T140000
```

Here's the relevant parts of the iCal file _after_ using the extension:
```
X-WR-TIMEZONE:Australia/Sydney
...
DTSTAMP;TZID=Australia/Sydney:20240803T120000
DTSTART;TZID=Australia/Sydney:20240803T120000
DTEND;TZID=Australia/Sydney:20240803T160000
```

We can see that the first iCal file is incorrect: the times are correct but the timezone is that of the server. The second iCal file has the timezone appropriate for my browser, and the times are adjusted two hours as one would expect.